### PR TITLE
Create timeouts WeakMap for each debounced method

### DIFF
--- a/src/debounce.es6.js
+++ b/src/debounce.es6.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const timeouts = new WeakMap();
 
 export default function debounceFactory(time = 500) {
 	return function debounce(target, name, descriptor) {
 		const value = descriptor.value || descriptor.initializer();
+		const timeouts = new WeakMap();
 
 		if (typeof value !== 'function') {
 			throw new TypeError('Only functions can be decorated with `debounce`.');

--- a/test/tests/debounce-test.es6.js
+++ b/test/tests/debounce-test.es6.js
@@ -9,6 +9,11 @@ class T {
 	highRateFn() {
 		this.count++;
 	}
+
+	@debounce(20)
+	decrementFn() {
+		this.count--;
+	}
 }
 
 describe('debounce', () => {
@@ -44,6 +49,24 @@ describe('debounce', () => {
 			}
 			catch(err) {
 				done(err);
+			}
+
+			done();
+		}, 40);
+	});
+
+	it('should work with multiple debounced methods in one class', (done) => {
+		const t = new T();
+
+		t.highRateFn();
+		t.decrementFn();
+
+		setTimeout(() => {
+			try {
+				t.count.should.equal(0);
+			}
+			catch(err) {
+				return done(err);
 			}
 
 			done();


### PR DESCRIPTION
If class have multiple debounced methods, and they will be called at the same time, only last one will be executed. For example:

``` js
class A {
  @debounce(100)
  foo() {
    console.log('foo')
  }

  @debounce(100)
  bar() {
    console.log('bar')
  }
}

let a = new A();
a.foo();
a.bar();
```

will print only:

```
bar
```

To fix this issue, each debounced method should have its own timeouts WeakMap.
